### PR TITLE
Fix hash table size field width

### DIFF
--- a/main.cpp
+++ b/main.cpp
@@ -8,6 +8,7 @@
 #include <QDialogButtonBox>
 #include <QLabel>
 #include <QSpinBox>
+#include <QSizePolicy>
 #include "mainwindow.h"
 #include "DataLoader.h"
 
@@ -21,6 +22,7 @@ int main(int argc, char *argv[])
     QLineEdit studEdit, concEdit;
     QSpinBox hashSizeSpin;
     hashSizeSpin.setMinimum(1);
+    hashSizeSpin.setSizePolicy(QSizePolicy::Expanding, QSizePolicy::Fixed);
     QPushButton browseStud("...");
     QPushButton browseConc("...");
     QWidget studRow, concRow;


### PR DESCRIPTION
## Summary
- expand hash table size spin box to match other input fields

## Testing
- `g++ -c main.cpp $(pkg-config --cflags Qt5Widgets)` *(fails: Package Qt5Widgets not found)*

------
https://chatgpt.com/codex/tasks/task_e_685ff118dba4832584190c7a6ec83c7a