### PR TITLE
Refactor student loader to use vector

### DIFF
--- a/src/core/dataloader/dataloader.cpp
+++ b/src/core/dataloader/dataloader.cpp
@@ -48,16 +48,17 @@ namespace {
 }
 
 namespace DataLoader {
-    Students_entry* loadStudents(int n, int& count, const std::string& filename) {
+    std::vector<Students_entry> loadStudents(int n, int& count, const std::string& filename) {
         std::string fname = filename.empty() ? "students.txt" : filename;
         qDebug() << "Loading students from" << QString::fromStdString(fname);
         std::ifstream input(fname);
         if (!input.is_open()) {
             qWarning() << "Не удалось открыть файл" << QString::fromStdString(fname);
             count = 0;
-            return new Students_entry[n];
+            return {};
         }
-        Students_entry* records = new Students_entry[n];
+        std::vector<Students_entry> records;
+        records.reserve(n);
         count = 0;
 
         std::string tmp;
@@ -85,7 +86,12 @@ namespace DataLoader {
                 break;
             record.teacher.initials = decodeCp1251(tmp);
 
-            records[count++] = record;
+            if (count < n) {
+                records.push_back(record);
+                ++count;
+            } else {
+                break;
+            }
         }
 
         qDebug() << "Loaded" << count << "students";

--- a/src/core/dataloader/dataloader.h
+++ b/src/core/dataloader/dataloader.h
@@ -7,7 +7,7 @@
 #include <string>
 
 namespace DataLoader {
-    Students_entry* loadStudents(int n, int& count, const std::string& filename);
+    std::vector<Students_entry> loadStudents(int n, int& count, const std::string& filename);
     std::vector<Concerts_entry> loadConcertsData(const std::string& filename);
     bool validateStudentsFile(const std::string& filename, int& count, std::string& error);
     bool validateConcertsFile(const std::string& filename, std::string& error);

--- a/src/main.cpp
+++ b/src/main.cpp
@@ -90,9 +90,9 @@ int main(int argc, char *argv[])
     int count = 0;
     std::string err;
     DataLoader::validateStudentsFile(studEdit.text().toStdString(), count, err);
-    Students_entry* records = DataLoader::loadStudents(count, count, studEdit.text().toStdString());
+    auto records = DataLoader::loadStudents(count, count, studEdit.text().toStdString());
     auto table = std::make_unique<HashTable>(hashSizeSpin.value());
-    for(int i=0;i<count;++i)
+    for(int i=0;i<count && i < static_cast<int>(records.size()); ++i)
         table->insert(records[i]);
 
     auto tree = std::make_unique<AVLTree>();
@@ -106,6 +106,5 @@ int main(int argc, char *argv[])
     w.show();
     int res = app.exec();
 
-    delete[] records;
     return res;
 }


### PR DESCRIPTION
## Summary
- refactor DataLoader::loadStudents to return `std::vector<Students_entry>`
- adjust declaration in header
- update main.cpp to use returned vector instead of raw array

## Testing
- `cmake ..` *(fails: Qt5 missing)*

------
https://chatgpt.com/codex/tasks/task_e_686119fa0ed88325808a4708914f9c38