### PR TITLE
Prevent duplicate entries

### DIFF
--- a/src/core/containers/avltree.cpp
+++ b/src/core/containers/avltree.cpp
@@ -62,17 +62,21 @@ AVLTree::Node* AVLTree::balance(Node* node) {
 }
 
 AVLTree::Node* AVLTree::insert(Node* node, const Concerts_entry& entry) {
-	if (!node) return new Node(entry);
+    if (!node)
+        return new Node(entry);
 
-	std::string fullNameCurrent = node->data.fio.surname + node->data.fio.name + node->data.fio.patronymic;
-	std::string fullNameNew = entry.fio.surname + entry.fio.name + entry.fio.patronymic;
+    if (entry == node->data)
+        return node;
 
-	if (fullNameNew < fullNameCurrent)
-		node->left = insert(node->left, entry);
-	else
-		node->right = insert(node->right, entry);
+    std::string fullNameCurrent = node->data.fio.surname + node->data.fio.name + node->data.fio.patronymic;
+    std::string fullNameNew = entry.fio.surname + entry.fio.name + entry.fio.patronymic;
 
-	return balance(node);
+    if (fullNameNew < fullNameCurrent)
+        node->left = insert(node->left, entry);
+    else
+        node->right = insert(node->right, entry);
+
+    return balance(node);
 }
 
 AVLTree::Node* AVLTree::findMin(Node* node) const{
@@ -118,8 +122,13 @@ void AVLTree::clear(Node* node) {
 	}
 }
 
-void AVLTree::insert(const Concerts_entry& entry) {
-	root = insert(root, entry);
+bool AVLTree::insert(const Concerts_entry& entry) {
+    Concerts_entry existing;
+    int dummy;
+    if (find(entry.fio, existing, dummy) && existing == entry)
+        return false;
+    root = insert(root, entry);
+    return true;
 }
 
 void AVLTree::remove(const FIO& fio) {

--- a/src/core/containers/avltree.h
+++ b/src/core/containers/avltree.h
@@ -40,7 +40,7 @@ public:
     AVLTree();
     ~AVLTree();
 
-    void insert(const Concerts_entry& entry);
+    bool insert(const Concerts_entry& entry);
     void remove(const FIO& fio);
     void toVector(std::vector<Concerts_entry>& vec) const;
     std::vector<Concerts_entry> searchByHall(const std::string& hall) const;

--- a/src/core/containers/hashtable.cpp
+++ b/src/core/containers/hashtable.cpp
@@ -61,6 +61,10 @@ void HashTable::checkResize() {
 }
 
 bool HashTable::insert(const Students_entry& record) {
+    Students_entry existing;
+    if (find(record.fio, existing) && existing == record)
+        return false;
+
     checkResize();
     int key = calculateKey(record.fio);
     int j = 0;

--- a/src/core/models/concert_entry.h
+++ b/src/core/models/concert_entry.h
@@ -9,6 +9,11 @@ struct Concerts_entry {
     std::string play;
     std::string hall;
     std::string date;
+
+    bool operator==(const Concerts_entry& other) const {
+        return fio == other.fio && play == other.play && hall == other.hall &&
+               date == other.date;
+    }
 };
 
 #endif

--- a/src/core/models/student_entry.h
+++ b/src/core/models/student_entry.h
@@ -9,6 +9,12 @@ struct Students_entry {
     FIO fio;
     std::string instrument;
     Teacher teacher;
+
+    bool operator==(const Students_entry& other) const {
+        return fio == other.fio && instrument == other.instrument &&
+               teacher.surname == other.teacher.surname &&
+               teacher.initials == other.teacher.initials;
+    }
 };
 
 

--- a/src/gui/concert_actions.cpp
+++ b/src/gui/concert_actions.cpp
@@ -16,8 +16,11 @@ void MainWindow::addConcert()
 {
     Concerts_entry e;
     if (concertDialog(e)) {
-        concerts->insert(e);
-        refreshTables();
+        if (!concerts->insert(e)) {
+            QMessageBox::warning(this, "Добавить концерт", "Такая запись уже существует");
+        } else {
+            refreshTables();
+        }
     }
 }
 
@@ -44,7 +47,10 @@ void MainWindow::editConcert()
         return;
 
     concerts->remove(oldEntry.fio);
-    concerts->insert(newEntry);
+    if (!concerts->insert(newEntry)) {
+        QMessageBox::warning(this, "Редактировать концерт", "Такая запись уже существует");
+        concerts->insert(oldEntry);
+    }
     refreshTables();
 }
 void MainWindow::searchConcert()
@@ -186,7 +192,10 @@ void MainWindow::concertCellChanged(int row, int column)
     }
 
     concerts->remove(oldEntry.fio);
-    concerts->insert(newEntry);
+    if (!concerts->insert(newEntry)) {
+        QMessageBox::warning(this, "Редактировать концерт", "Такая запись уже существует");
+        concerts->insert(oldEntry);
+    }
     refreshTables();
     ui->concertsTable->setCurrentCell(row, column);
 }

--- a/src/gui/student_actions.cpp
+++ b/src/gui/student_actions.cpp
@@ -14,8 +14,11 @@ void MainWindow::addStudent()
 {
     Students_entry se;
     if (studentDialog(se)) {
-        students->insert(se);
-        refreshTables();
+        if (!students->insert(se)) {
+            QMessageBox::warning(this, "Добавить ученика", "Такая запись уже существует");
+        } else {
+            refreshTables();
+        }
     }
 }
 
@@ -43,7 +46,10 @@ void MainWindow::editStudent()
         return;
 
     students->remove(oldEntry.fio);
-    students->insert(newEntry);
+    if (!students->insert(newEntry)) {
+        QMessageBox::warning(this, "Редактировать ученика", "Такая запись уже существует");
+        students->insert(oldEntry);
+    }
     refreshTables();
 }
 
@@ -173,7 +179,10 @@ void MainWindow::studentCellChanged(int row, int column)
     }
 
     students->remove(oldEntry.fio);
-    students->insert(newEntry);
+    if (!students->insert(newEntry)) {
+        QMessageBox::warning(this, "Редактировать ученика", "Такая запись уже существует");
+        students->insert(oldEntry);
+    }
     refreshTables();
     ui->studentsTable->setCurrentCell(row, column);
 }


### PR DESCRIPTION
## Summary
- add equality operators for data models
- detect duplicates on student and concert insertion
- reject duplicates in GUI actions with warnings

## Testing
- `cmake ..` *(fails: Qt5 not found)*
- `g++ -std=c++17 -I src -I src/core -I src/core/models -c src/core/containers/hashtable.cpp`
- `g++ -std=c++17 -I src -I src/core -I src/core/models -fsyntax-only src/core/containers/avltree.cpp` *(fails: QTreeWidget missing)*

------
https://chatgpt.com/codex/tasks/task_e_6863979ea6288325bd658209dfbf7c4f