### PR TITLE
Update hash column to show key

### DIFF
--- a/src/core/containers/hashtable.h
+++ b/src/core/containers/hashtable.h
@@ -16,12 +16,12 @@ private:
     int fullSize;
     int size;
 
-    int calculateKey(const FIO& fio, const std::string& instrument) const;
     int hash(int key, int j, int s) const;
     void resize(int newSize);
     void checkResize();
 
 public:
+    int calculateKey(const FIO& fio, const std::string& instrument) const;
     int initialIndex(const FIO& fio, const std::string& instrument) const;
 
     explicit HashTable(int initSize);

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -103,7 +103,7 @@ void MainWindow::refreshTables()
                 return it;
             };
 
-            int h = students->initialIndex(st.fio, st.instrument);
+            int h = students->calculateKey(st.fio, st.instrument);
             ui->studentsTable->setItem(row, 0, makeItem(QString::number(h)));
             ui->studentsTable->setItem(row, 1, makeItem(QString::fromStdString(st.fio.surname)));
             ui->studentsTable->setItem(row, 2, makeItem(QString::fromStdString(st.fio.name)));


### PR DESCRIPTION
## Summary
- expose `calculateKey` publicly in `HashTable`
- display hash key in students table

## Testing
- `cmake -S . -B build` *(fails: Qt5 not found)*
- `qmake` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_686de058ec54832593f90aadad44c227