### PR TITLE
Implement theme tweaks and status column

### DIFF
--- a/resources/themes.json
+++ b/resources/themes.json
@@ -23,7 +23,8 @@
     "button": "#fa8072",
     "buttontext": "#000000",
     "highlight": "#3cb371",
-    "highlightedtext": "#000000"
+    "highlightedtext": "#000000",
+    "font": "Verdana"
   },
   "sonic": {
     "window": "#2066ca",
@@ -35,29 +36,32 @@
     "buttontext": "#ffffff",
     "highlight": "#ff0000",
     "highlightedtext": "#ffffff",
-    "link": "#ffff00"
+    "link": "#ffff00",
+    "font": "Arial"
   },
   "gojo": {
-    "window": "#dcdcff",
+    "window": "#e8e0ff",
     "windowtext": "#000000",
-    "base": "#f0f0ff",
-    "alternatebase": "#dcdcff",
+    "base": "#f6f2ff",
+    "alternatebase": "#e8e0ff",
     "text": "#000000",
-    "button": "#c8c8ff",
+    "button": "#d6ccff",
     "buttontext": "#000000",
-    "highlight": "#00aaff",
-    "highlightedtext": "#ffffff"
+    "highlight": "#8060ff",
+    "highlightedtext": "#ffffff",
+    "link": "#ff6666",
+    "font": "Courier New"
   },
-  "marisa": {
-    "window": "#334433",
-    "windowtext": "#ffffff",
-    "base": "#112211",
-    "alternatebase": "#334433",
-    "text": "#ffffff",
-    "button": "#334433",
-    "buttontext": "#ffffff",
-    "highlight": "#55cc00",
-    "highlightedtext": "#000000",
-    "link": "#ffdd00"
+  "sans": {
+    "window": "#f0f8ff",
+    "windowtext": "#000000",
+    "base": "#e0efff",
+    "alternatebase": "#f0f8ff",
+    "text": "#000000",
+    "button": "#d0e0ff",
+    "buttontext": "#000000",
+    "highlight": "#1f5fd2",
+    "highlightedtext": "#ffffff",
+    "link": "#1a0eff"
   }
 }

--- a/src/core/containers/hashtable.h
+++ b/src/core/containers/hashtable.h
@@ -37,6 +37,7 @@ public:
     int getSize() const { return size; }
     int getFullSize() const { return fullSize; }
     bool isOccupied(int index) const { return table[index].status == 1; }
+    int statusAt(int index) const { return table[index].status; }
     const Students_entry& getEntry(int index) const { return table[index].record; }
 };
 

--- a/src/gui/mainwindow.cpp
+++ b/src/gui/mainwindow.cpp
@@ -34,16 +34,16 @@ MainWindow::MainWindow(HashTable* studentsTable, AVLTree* concertTree,
     QAction* gojoAct = settingsMenu->addAction("\320\223\320\276\320\264\320\266\320\276 \320\241\320\260\321\202\320\276\321\200\321\203");
     gojoAct->setCheckable(true);
     gojoAct->setActionGroup(themeGroup);
-    QAction* marisaAct = settingsMenu->addAction("\320\234\320\260\321\200\320\270\321\201\321\213 \320\232\320\270\321\200\320\270\321\201\320\260\320\274\320\265 \320\270 Wriggle Nightbug");
-    marisaAct->setCheckable(true);
-    marisaAct->setActionGroup(themeGroup);
+    QAction* sansAct = settingsMenu->addAction("\320\241\320\260\320\275\321\201");
+    sansAct->setCheckable(true);
+    sansAct->setActionGroup(themeGroup);
     QSettings set;
     Theme current = themeFromString(set.value("theme", "dark").toString());
     switch (current) {
     case Theme::Madagascar: madAct->setChecked(true); break;
     case Theme::Sonic: sonicAct->setChecked(true); break;
     case Theme::GojoSatoru: gojoAct->setChecked(true); break;
-    case Theme::MarisaWriggle: marisaAct->setChecked(true); break;
+    case Theme::Sans: sansAct->setChecked(true); break;
     default: darkAct->setChecked(true); break;
     }
     auto apply = [](Theme t){
@@ -54,7 +54,7 @@ MainWindow::MainWindow(HashTable* studentsTable, AVLTree* concertTree,
     connect(madAct, &QAction::triggered, this, [=]{ apply(Theme::Madagascar); });
     connect(sonicAct, &QAction::triggered, this, [=]{ apply(Theme::Sonic); });
     connect(gojoAct, &QAction::triggered, this, [=]{ apply(Theme::GojoSatoru); });
-    connect(marisaAct, &QAction::triggered, this, [=]{ apply(Theme::MarisaWriggle); });
+    connect(sansAct, &QAction::triggered, this, [=]{ apply(Theme::Sans); });
     connect(ui->addStudentButton, &QPushButton::clicked, this, &MainWindow::addStudent);
     connect(ui->removeStudentButton, &QPushButton::clicked, this, &MainWindow::removeStudent);
     connect(ui->editStudentButton, &QPushButton::clicked, this, &MainWindow::editStudent);
@@ -83,6 +83,7 @@ MainWindow::MainWindow(HashTable* studentsTable, AVLTree* concertTree,
     connect(ui->dateFilterCheck, &QCheckBox::toggled, this, &MainWindow::updateReport);
     ui->concertTree->setHeaderHidden(true);
     ui->reportTable->setEditTriggers(QAbstractItemView::NoEditTriggers);
+    ui->studentsVectorTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
     ui->studentsTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
     ui->concertsTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
     ui->reportTable->horizontalHeader()->setSectionResizeMode(QHeaderView::Stretch);
@@ -90,6 +91,8 @@ MainWindow::MainWindow(HashTable* studentsTable, AVLTree* concertTree,
     ui->mainSplitter->setStretchFactor(1, 1);
     ui->concertsSplitter->setStretchFactor(0, 1);
     ui->concertsSplitter->setStretchFactor(1, 1);
+    ui->verticalLayout->setStretch(0, 0);
+    ui->verticalLayout->setStretch(1, 1);
     refreshTables();
     updateConcertTree();
 }
@@ -151,9 +154,9 @@ void MainWindow::refreshTables()
     ui->studentsTable->blockSignals(true);
     ui->studentsTable->clearContents();
     ui->studentsTable->setRowCount(students->getFullSize());
-    ui->studentsTable->setColumnCount(6);
+    ui->studentsTable->setColumnCount(7);
     QStringList studentHeaders;
-    studentHeaders << "Хэш" << "Фамилия" << "Имя" << "Отчество" << "Инструмент" << "Учитель";
+    studentHeaders << "Хэш" << "Фамилия" << "Имя" << "Отчество" << "Инструмент" << "Учитель" << "Статус";
     ui->studentsTable->setHorizontalHeaderLabels(studentHeaders);
     double loadFactor = static_cast<double>(students->getSize()) / students->getFullSize();
     ui->tableInfoLabel->setText(QString("Размер таблицы: %1, заполненность: %2%")
@@ -183,10 +186,12 @@ void MainWindow::refreshTables()
             ui->studentsTable->setItem(i, 3, makeItem(QString::fromStdString(st.fio.patronymic), true));
             ui->studentsTable->setItem(i, 4, makeItem(QString::fromStdString(st.instrument), true));
             ui->studentsTable->setItem(i, 5, makeItem(QString::fromStdString(st.teacher.surname + " " + st.teacher.initials), true));
+            ui->studentsTable->setItem(i, 6, makeItem(QString::number(students->statusAt(i)), false));
             studentRowMap.push_back(i);
         } else {
-            for (int c = 0; c < 6; ++c)
+            for (int c = 0; c < 7; ++c)
                 ui->studentsTable->setItem(i, c, makeItem("", false));
+            ui->studentsTable->setItem(i, 6, makeItem(QString::number(students->statusAt(i)), false));
             studentRowMap.push_back(-1);
         }
     }

--- a/src/gui/mainwindow.ui
+++ b/src/gui/mainwindow.ui
@@ -31,10 +31,22 @@
                  <property name="text">
                   <string/>
                  </property>
-                 <property name="alignment">
-                  <set>Qt::AlignCenter</set>
-                 </property>
-                </widget>
+                <property name="alignment">
+                 <set>Qt::AlignCenter</set>
+                </property>
+                <property name="sizePolicy">
+                 <sizepolicy hsizetype="Preferred" vsizetype="Fixed">
+                  <horstretch>0</horstretch>
+                  <verstretch>0</verstretch>
+                 </sizepolicy>
+                </property>
+                <property name="maximumSize">
+                 <size>
+                  <width>16777215</width>
+                  <height>20</height>
+                 </size>
+                </property>
+               </widget>
                </item>
                <item>
                 <widget class="QSplitter" name="studentsSplitter">

--- a/src/gui/theme.cpp
+++ b/src/gui/theme.cpp
@@ -7,6 +7,7 @@
 #include <QJsonDocument>
 #include <QJsonObject>
 #include <QHash>
+#include <QFont>
 
 namespace {
 QJsonObject loadThemes()
@@ -50,7 +51,7 @@ Theme themeFromString(const QString& name) {
     if (n == "madagascar") return Theme::Madagascar;
     if (n == "sonic") return Theme::Sonic;
     if (n == "gojo" || n == "gojosatoru") return Theme::GojoSatoru;
-    if (n == "marisa" || n == "marisawriggle") return Theme::MarisaWriggle;
+    if (n == "sans") return Theme::Sans;
 
     return Theme::Dark;
 }
@@ -60,7 +61,7 @@ QString themeToString(Theme t) {
     case Theme::Madagascar: return "madagascar";
     case Theme::Sonic: return "sonic";
     case Theme::GojoSatoru: return "gojo";
-    case Theme::MarisaWriggle: return "marisa";
+    case Theme::Sans: return "sans";
     default: return "dark";
     }
 }
@@ -71,11 +72,22 @@ void applyTheme(Theme t, QApplication& app) {
 
     QJsonObject themeObj = themes().value(themeToString(t)).toObject();
     for (auto it = themeObj.constBegin(); it != themeObj.constEnd(); ++it) {
+        if (it.key().toLower() == "font")
+            continue;
         QPalette::ColorRole role = roleFromString(it.key());
         QColor color(it.value().toString());
         if (color.isValid())
             p.setColor(role, color);
     }
     app.setPalette(p);
+    if (t == Theme::Sans) {
+        app.setFont(QFont("Comic Sans MS"));
+    } else {
+        QString fontName = themeObj.value("font").toString();
+        if (!fontName.isEmpty())
+            app.setFont(QFont(fontName));
+        else
+            app.setFont(QFont());
+    }
 }
 

--- a/src/gui/theme.h
+++ b/src/gui/theme.h
@@ -4,7 +4,7 @@
 #include <QApplication>
 #include <QString>
 
-enum class Theme { Dark, Madagascar, Sonic, GojoSatoru, MarisaWriggle };
+enum class Theme { Dark, Madagascar, Sonic, GojoSatoru, Sans };
 
 Theme themeFromString(const QString& name);
 QString themeToString(Theme t);


### PR DESCRIPTION
## Summary
- remove Marisa theme references
- support per-theme fonts via JSON
- refine Sans and Gojo palettes
- add status column to hash table display
- expose entry status via `statusAt`

## Testing
- `cmake -S . -B build` *(fails: Qt5 not found)*
- `make -C build -j$(nproc)` *(fails: No targets specified and no makefile found)*

------
https://chatgpt.com/codex/tasks/task_e_686e6b83e32883258b768bf39b2a428d