### PR TITLE
Update themes and restore default font

### DIFF
--- a/resources/themes.json
+++ b/resources/themes.json
@@ -24,7 +24,7 @@
     "buttontext": "#000000",
     "highlight": "#3cb371",
     "highlightedtext": "#000000",
-    "font": "Verdana"
+    "font": "Trebuchet MS"
   },
   "sonic": {
     "window": "#2066ca",
@@ -37,20 +37,20 @@
     "highlight": "#ff0000",
     "highlightedtext": "#ffffff",
     "link": "#ffff00",
-    "font": "Arial"
+    "font": "Comic Sans MS"
   },
   "gojo": {
-    "window": "#e8e0ff",
-    "windowtext": "#000000",
-    "base": "#f6f2ff",
-    "alternatebase": "#e8e0ff",
-    "text": "#000000",
-    "button": "#d6ccff",
-    "buttontext": "#000000",
-    "highlight": "#8060ff",
+    "window": "#7d35ff",
+    "windowtext": "#ffffff",
+    "base": "#0015ff",
+    "alternatebase": "#7d35ff",
+    "text": "#ffffff",
+    "button": "#c012ff",
+    "buttontext": "#ffffff",
+    "highlight": "#ff0066",
     "highlightedtext": "#ffffff",
-    "link": "#ff6666",
-    "font": "Courier New"
+    "link": "#ff0000",
+    "font": "Impact"
   },
   "sans": {
     "window": "#f0f8ff",

--- a/src/gui/theme.cpp
+++ b/src/gui/theme.cpp
@@ -10,6 +10,11 @@
 #include <QFont>
 
 namespace {
+QFont& defaultFont()
+{
+    static QFont f;
+    return f;
+}
 QJsonObject loadThemes()
 {
     QFile f(":/themes.json");
@@ -70,6 +75,9 @@ void applyTheme(Theme t, QApplication& app) {
     app.setStyle(QStyleFactory::create("Fusion"));
     QPalette p = app.style()->standardPalette();
 
+    if (defaultFont().family().isEmpty())
+        defaultFont() = app.font();
+
     QJsonObject themeObj = themes().value(themeToString(t)).toObject();
     for (auto it = themeObj.constBegin(); it != themeObj.constEnd(); ++it) {
         if (it.key().toLower() == "font")
@@ -87,7 +95,7 @@ void applyTheme(Theme t, QApplication& app) {
         if (!fontName.isEmpty())
             app.setFont(QFont(fontName));
         else
-            app.setFont(QFont());
+            app.setFont(defaultFont());
     }
 }
 


### PR DESCRIPTION
## Summary
- refine theme colors and fonts
- ensure default font resets on theme switch

## Testing
- `cmake ..` *(fails: Qt5Config.cmake missing)*
- `make` *(fails: no makefile)*

------
https://chatgpt.com/codex/tasks/task_e_686e713f5b8c8325ac81c2bad822cceb